### PR TITLE
Fixed. runtime error: index out of range when no events

### DIFF
--- a/model/connpass/group.go
+++ b/model/connpass/group.go
@@ -29,7 +29,7 @@ func GetGroup(memcachedConfig *model.MemcachedConfig, groupName string, currentT
 	updatedAt := group.MaxEventsUpdatedAt()
 
 	if updatedAt != nil {
-		group.UpdatedAt = *updatedAt
+		group.UpdatedAt = updatedAt
 	}
 
 	return &group, nil

--- a/model/connpass/group_test.go
+++ b/model/connpass/group_test.go
@@ -39,7 +39,7 @@ func TestGetGroup(t *testing.T) {
 		wantEventCount int
 		wantURL        string
 		wantTitle      string
-		wantUpdatedAt  time.Time
+		wantUpdatedAt  *time.Time
 	}{
 		{
 			name: "successful",
@@ -58,7 +58,7 @@ func TestGetGroup(t *testing.T) {
 			wantEventCount: 27,
 			wantURL:        "https://gocon.connpass.com/",
 			wantTitle:      "Go Conference - connpass",
-			wantUpdatedAt:  time.Date(2019, 7, 25, 22, 24, 0, 0, model.JST),
+			wantUpdatedAt:  tp(time.Date(2019, 7, 25, 22, 24, 0, 0, model.JST)),
 		},
 	}
 	for _, tt := range tests {

--- a/model/doorkeeper/group.go
+++ b/model/doorkeeper/group.go
@@ -67,7 +67,7 @@ func GetGroup(accessToken string, groupName string, currentTime time.Time) (*mod
 	updatedAt := group.MaxEventsUpdatedAt()
 
 	if updatedAt != nil {
-		group.UpdatedAt = *updatedAt
+		group.UpdatedAt = updatedAt
 	}
 
 	return &group, nil

--- a/model/doorkeeper/group_test.go
+++ b/model/doorkeeper/group_test.go
@@ -46,7 +46,7 @@ func TestGetGroup(t *testing.T) {
 		wantEventCount int
 		wantURL        string
 		wantTitle      string
-		wantUpdatedAt  time.Time
+		wantUpdatedAt  *time.Time
 	}{
 		{
 			name: "successful",
@@ -66,7 +66,7 @@ func TestGetGroup(t *testing.T) {
 			wantEventCount: 1,
 			wantURL:        "https://trbmeetup.doorkeeper.jp/",
 			wantTitle:      "Tokyo Rubyist Meetup | Doorkeeper",
-			wantUpdatedAt:  time.Date(2018, 5, 11, 0, 7, 44, 270000000, time.UTC),
+			wantUpdatedAt:  tp(time.Date(2018, 5, 11, 0, 7, 44, 270000000, time.UTC)),
 		},
 	}
 	for _, tt := range tests {

--- a/model/group.go
+++ b/model/group.go
@@ -15,7 +15,7 @@ const (
 type Group struct {
 	Title     string
 	URL       string
-	UpdatedAt time.Time
+	UpdatedAt *time.Time
 	Events    []Event
 }
 
@@ -53,10 +53,13 @@ func (g *Group) ToIcal() string {
 // ToAtom return atom formatted group
 func (g *Group) ToAtom() (string, error) {
 	feed := &feeds.Feed{
-		Title:   g.Title,
-		Link:    &feeds.Link{Href: g.URL},
-		Items:   []*feeds.Item{},
-		Updated: g.UpdatedAt.In(JST),
+		Title: g.Title,
+		Link:  &feeds.Link{Href: g.URL},
+		Items: []*feeds.Item{},
+	}
+
+	if g.UpdatedAt != nil {
+		feed.Updated = g.UpdatedAt.In(JST)
 	}
 
 	for _, e := range g.Events {

--- a/model/group_test.go
+++ b/model/group_test.go
@@ -144,7 +144,7 @@ func TestGroup_ToAtom(t *testing.T) {
 	type fields struct {
 		Title     string
 		URL       string
-		UpdatedAt time.Time
+		UpdatedAt *time.Time
 		Events    []Event
 	}
 	tests := []struct {
@@ -157,7 +157,7 @@ func TestGroup_ToAtom(t *testing.T) {
 			fields: fields{
 				Title:     "Go Conference - connpass",
 				URL:       "https://gocon.connpass.com/",
-				UpdatedAt: time.Date(2019, 7, 25, 22, 24, 0, 0, JST),
+				UpdatedAt: tp(time.Date(2019, 7, 25, 22, 24, 0, 0, JST)),
 				Events: []Event{
 					{
 						Title:     "Go 1.13 Release Party in Tokyo",
@@ -176,7 +176,7 @@ func TestGroup_ToAtom(t *testing.T) {
 			fields: fields{
 				Title:     "TokyuRubyKaigi | Doorkeeper",
 				URL:       "https://tokyu-rubykaigi.doorkeeper.jp/",
-				UpdatedAt: time.Date(2019, 6, 29, 4, 0, 40, 747000000, time.UTC),
+				UpdatedAt: tp(time.Date(2019, 6, 29, 4, 0, 40, 747000000, time.UTC)),
 				Events: []Event{
 					{
 						Title:     "TokyuRubyKaigi13 一般参加者募集(LT発表者は登録不要です)",
@@ -251,7 +251,7 @@ func TestGroup_MaxEventsUpdatedAt(t *testing.T) {
 	type fields struct {
 		Title     string
 		URL       string
-		UpdatedAt time.Time
+		UpdatedAt *time.Time
 		Events    []Event
 	}
 	tests := []struct {


### PR DESCRIPTION
```
2019/08/13 02:25:58 http: panic serving 127.0.0.1:27433: runtime error: index out of range
goroutine 442 [running]:
net/http.(*conn).serve.func1(0xc0000a99a0)
	/usr/local/go/src/net/http/server.go:1769 +0x139
panic(0x9906c0, 0xf41230)
	/usr/local/go/src/runtime/panic.go:522 +0x1b5
github.com/sue445/condo3/model.maxTime(0x0, 0x0, 0x0, 0x8e221a, 0x203000, 0x203000)
	/tmp/staging/srv/model/group.go:98 +0xd6
github.com/sue445/condo3/model.(*Group).ApplyUpdatedAt(0xc0003b67d0)
	/tmp/staging/srv/model/group.go:90 +0x133
github.com/sue445/condo3/model/connpass.GetGroup(0xc000261440, 0xc0000308e3, 0xd, 0xbf4ca5cd91818385, 0xc48e047d02, 0xf55940, 0x30, 0x9f9720, 0x1)
	/tmp/staging/srv/model/connpass/group.go:28 +0x197
github.com/sue445/condo3/api.(*Handler).ConnpassHandler(0xc000093240, 0xb19700, 0xc0001d22a0, 0xc0000fca00)
	/tmp/staging/srv/api/connpass_handler.go:15 +0xf4
net/http.HandlerFunc.ServeHTTP(0xc0003fe640, 0xb19700, 0xc0001d22a0, 0xc0000fca00)
	/usr/local/go/src/net/http/server.go:1995 +0x44
github.com/gorilla/mux.(*Router).ServeHTTP(0xc0002d60c0, 0xb19700, 0xc0001d22a0, 0xc0001d0c00)
	/go/pkg/mod/github.com/gorilla/mux@v1.7.3/mux.go:212 +0xe3
net/http.(*ServeMux).ServeHTTP(0xf55800, 0xb19700, 0xc0001d22a0, 0xc0001d0c00)
	/usr/local/go/src/net/http/server.go:2375 +0x1d6
net/http.serverHandler.ServeHTTP(0xc000095110, 0xb19700, 0xc0001d22a0, 0xc0001d0c00)
	/usr/local/go/src/net/http/server.go:2774 +0xa8
net/http.(*conn).serve(0xc0000a99a0, 0xb1ab00, 0xc00006a500)
	/usr/local/go/src/net/http/server.go:1878 +0x851
```