### PR TITLE
Fix deploy

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -105,4 +105,4 @@ workflows:
           context: gcp_condo3
           filters:
             branches:
-              only: fix_deploy
+              only: master

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -105,4 +105,4 @@ workflows:
           context: gcp_condo3
           filters:
             branches:
-              only: master
+              only: fix_deploy

--- a/app.yaml
+++ b/app.yaml
@@ -1,4 +1,4 @@
-runtime: go116
+runtime: go119
 
 handlers:
   # Otherwise, find file in static directory


### PR DESCRIPTION
https://app.circleci.com/pipelines/github/sue445/condo3/2062/workflows/6a3c7957-6f92-45a1-8c8d-5b5caaf41c04/jobs/8244

```
File upload done.
ERROR: (gcloud.app.deploy) Error Response: [9] Cloud build da782ac1-422d-4054-96eb-9d86756b6fd8 status: FAILURE
go: github.com/getsentry/sentry-go@v0.16.0 requires
	github.com/gin-gonic/gin@v1.8.1: missing go.sum entry; to add it:
	go mod download github.com/gin-gonic/gin

```